### PR TITLE
Identical leaf patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smartling/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.5-0",
+  "version": "0.10.5-1",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smartling/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.4-0",
+  "version": "0.10.5-0",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -113,12 +113,24 @@ class DraftEditorLeaf extends React.Component<Props> {
 
   shouldComponentUpdate(nextProps: Props): boolean {
     const leafNode = ReactDOM.findDOMNode(this.refs.leaf);
+    const {selection} = nextProps;
+    let hasSelection = false;
+    // If selection state is within the current leaf
+    // force an update
+    if (selection && selection.getHasFocus()) {
+      const {block, start, text} = nextProps;
+      const blockKey = block.getKey();
+      const end = start + text.length;
+      hasSelection = selection.hasEdgeWithin(blockKey, start, end);
+    }
+
     invariant(leafNode, 'Missing leafNode');
-    return (
+    const shouldUpdate =
       leafNode.textContent !== nextProps.text ||
       nextProps.styleSet !== this.props.styleSet ||
-      nextProps.forceSelection
-    );
+      hasSelection ||
+      nextProps.forceSelection;
+    return shouldUpdate;
   }
 
   componentDidUpdate(): void {


### PR DESCRIPTION
This is the fix for https://github.com/facebook/draft-js/pull/1810

We are currently on a different version, hence why the changes are slightly different. I'll talk to @Tobitron about prioritizing the upgrade. Looks like there are going to be some pivots back in 0.10.6 so we may want to wait until that release (or maybe they will finally release 0.11.0, or even better, 1.0.0)