### PR TITLE
Fix issue w/ dual editor selection and inaccurate block key lookup

### DIFF
--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -43,6 +43,11 @@ function getUpdatedSelectionState(
 
   var anchorPath = DraftOffsetKey.decode(anchorKey);
   var anchorBlockKey = anchorPath.blockKey;
+
+  if (!editorState.getBlockTree(anchorBlockKey)) {
+    return selection;
+  }
+
   var anchorLeaf = editorState
     .getBlockTree(anchorBlockKey)
     .getIn([


### PR DESCRIPTION
Fixes issue where drafts improperly looks up the block key of the current editor. It prevents methods from being called on the blockTree. Not trying to fix upstream issue where block key logic is handled.